### PR TITLE
Additional features: Go templating in messages and titles & dispatch alerts with error-message for misconfigured alerts or faulty templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,28 @@ Flags:
                                 Metrics Namespace ($METRICS_NAMESPACE)
   --metrics_path="/metrics"     Path under which to expose metrics for the bridge ($METRICS_PATH)
   --extended_details            When enabled, alerts are presented in HTML format and include colorized status (FIR|RES), alert start time, and a link to the generator of the alert ($EXTENDED_DETAILS)
+  --dispatch_errors             When enabled, alerts will be tried to dispatch with a error-message regarding faulty templating or missing fields to help debugging ($DISPATCH_ERRORS)
   --debug                       Enable debug output of the server
   --version                     Show application version.
+```
+
+### Templating
+The bridge now supports [Go templating](https://golang.org/pkg/text/template/), so you can customize the alertmessages further.  
+For example add following line to the title:  
+`{{if eq .Status "firing"}}🔥{{else}}✅{{end}}`  
+This differentiates firing from resolving alerts.  
+  
+Also, there are two methods you can use for additional customisation:
+```
+.Values                 Access alert-values, -labels and -metrics. 
+                        Returns list of:
+                            Metric  string
+                            Labels  map[string]string
+                            Value   float64
+              
+.Humanize <float64>     Rounds float and stripps trailing zeros to return more readable float.
+                        .Humanize 5.3234134 returns 5.32
+                        .Humanize 5.0       returns 5
 ```
 
 ## Metrics

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Flags:
 ```
 
 ### Templating
-The bridge now supports [Go templating](https://golang.org/pkg/text/template/), so you can customize the alertmessages further.  
+The bridge now supports [Go templating](https://golang.org/pkg/text/template/), so you can customize the alert messages further with templates in the title and message annotations, that you can configure in the Grafana alertmanager section.  
 For example add following line to the title:  
 `{{if eq .Status "firing"}}🔥{{else}}✅{{end}}`  
 This differentiates firing from resolving alerts.  
@@ -77,6 +77,20 @@ Also, there are two methods you can use for additional customisation:
                         .Humanize 5.3234134 returns 5.32
                         .Humanize 5.0       returns 5
 ```
+To give further information and examples for use-cases for these methods:
+Imagine a simple uptime-metric for multiple instances or jobs. If you configure an alert, it would fire if any instance or alert is down. The message would probably say something like "an instance or job is down".
+But from the message you would not know which of the jobs or instances is the down one, or if there are multiple. To address this you have to use the `.Values` method. A alert-description could look like this:
+```
+{{if eq .Status "firing"}}
+Following Providers are down: 
+{{range $i, $provider := .Values}}
+{{$provider.Labels.job}}, 
+{{end}}
+{{else}}
+All providers are back up
+{{end}}
+```
+Now if the alert fires it would list the jobs that are down. Which information the `.Values` method contains can be inspected in the Grafana alertmanager when configuring an alert and clicking the `Preview Alert` button.
 
 ## Metrics
 The bridge tracks telemetry data for metrics within the server as well as exposes gotify's health (obtained via the /health endpoint) as prometheus metrics. Therefore, the bridge can be scraped with Prometheus on /metrics to obtain these metrics.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/DRuggeri/alertmanager_gotify_bridge
 go 1.14
 
 require (
+	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/common v0.20.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/DRuggeri/alertmanager_gotify_bridge
 go 1.14
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/common v0.20.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -91,6 +92,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -142,8 +144,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -200,6 +204,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -240,7 +245,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -255,6 +259,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -354,6 +359,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -384,6 +390,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -397,6 +404,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type Notification struct {
 type Alert struct {
 	Annotations  map[string]string
 	Status       string
+	Labels       map[string]string
 	GeneratorURL string
 	StartsAt     string
 	ValueString  string

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
@@ -469,4 +471,9 @@ func (a Alert) Values() []AlertValues {
 	}
 
 	return alertValues
+}
+
+func (a Alert) Humanize(in float64) string {
+	in = math.Round(in*100) / 100
+	return humanize.Ftoa(in)
 }

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 
 			metrics["alerts_received"]++
 			if *svr.debug {
-				log.Printf("Alert %d", idx)
+				log.Printf("    Alert %d", idx)
 			}
 
 			if *extendedDetails {
@@ -284,7 +284,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 					if *svr.dispatchErrors {
 						proceed = true
 						title = "Alertmanager-Gotify-Bridge Error"
-						message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+						message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 					}
 				} else {
 					var templatedTitle bytes.Buffer
@@ -300,7 +300,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 						if *svr.dispatchErrors {
 							proceed = true
 							title = "Alertmanager-Gotify-Bridge Error"
-							message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+							message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 						}
 					} else {
 						title += templatedTitle.String()
@@ -308,7 +308,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if *svr.debug {
-					log.Printf("title: %s\n", title)
+					log.Printf("    title: %s\n", title)
 				}
 			} else {
 				proceed = false
@@ -321,7 +321,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				if *svr.dispatchErrors {
 					proceed = true
 					title = "Alertmanager-Gotify-Bridge Error"
-					message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+					message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 				}
 			}
 
@@ -338,7 +338,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 					if *svr.dispatchErrors {
 						proceed = true
 						title = "Alertmanager-Gotify-Bridge Error"
-						message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+						message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 					}
 				} else {
 					var templatedMessage bytes.Buffer
@@ -354,7 +354,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 						if *svr.dispatchErrors {
 							proceed = true
 							title = "Alertmanager-Gotify-Bridge Error"
-							message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+							message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 						}
 					} else {
 						message = templatedMessage.String()
@@ -362,7 +362,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if *svr.debug {
-					log.Printf("message: %s\n", message)
+					log.Printf("    message: %s\n", message)
 				}
 			} else {
 				proceed = false
@@ -375,7 +375,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				if *svr.dispatchErrors {
 					proceed = true
 					title = "Alertmanager-Gotify-Bridge Error"
-					message = fmt.Sprintf("Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
+					message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", errMsg, b)
 				}
 			}
 
@@ -384,12 +384,12 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				if err == nil {
 					priority = tmp
 					if *svr.debug {
-						log.Printf("priority: %d\n", priority)
+						log.Printf("    priority: %d\n", priority)
 					}
 				}
 			} else {
 				if *svr.debug {
-					log.Printf("priority annotation (%s) missing - falling back to default (%d)\n", *svr.priorityAnnotation, *svr.defaultPriority)
+					log.Printf("    priority annotation (%s) missing - falling back to default (%d)\n", *svr.priorityAnnotation, *svr.defaultPriority)
 				}
 			}
 
@@ -408,7 +408,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 
 			if proceed {
 				if *svr.debug {
-					log.Printf("Dispatching to gotify...\n")
+					log.Printf("    Dispatching to gotify...\n")
 				}
 				outbound := GotifyNotification{
 					Title:    title,
@@ -418,7 +418,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				}
 				msg, _ := json.Marshal(outbound)
 				if *svr.debug {
-					log.Printf("Outbound: %s\n", string(msg))
+					log.Printf("    Outbound: %s\n", string(msg))
 				}
 
 				client := http.Client{
@@ -427,7 +427,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 
 				request, err := http.NewRequest("POST", *svr.gotifyEndpoint, bytes.NewBuffer(msg))
 				if err != nil {
-					log.Printf("Error setting up request: %s", err)
+					log.Printf("    Error setting up request: %s", err)
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					metrics["alerts_failed"]++
 					return
@@ -437,7 +437,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 
 				resp, err := client.Do(request)
 				if err != nil {
-					log.Printf("Error dispatching to Gotify: %s", err)
+					log.Printf("    Error dispatching to Gotify: %s", err)
 					respCode = http.StatusInternalServerError
 					text = append(text, err.Error())
 					metrics["alerts_failed"]++
@@ -446,7 +446,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 					defer resp.Body.Close()
 					body, _ := ioutil.ReadAll(resp.Body)
 					if *svr.debug {
-						log.Printf("Dispatched! Response was %s\n", body)
+						log.Printf("    Dispatched! Response was %s\n", body)
 					}
 					if resp.StatusCode != 200 {
 						log.Printf("Non-200 response from gotify at %s. Code: %d, Status: %s (enable debug to see body)",
@@ -462,7 +462,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				}
 			} else {
 				if *svr.debug {
-					log.Printf("Unable to dispatch!\n")
+					log.Printf("    Unable to dispatch!\n")
 					respCode = http.StatusBadRequest
 					text = []string{"Incomplete request"}
 					metrics["alerts_invalid"]++


### PR DESCRIPTION
Hi!
I extended the bridge by adding support for Go templating in titles and messages for further customization. To be able to use alert values I also implemented a method to parse them from the valueString-object, sent by grafana. 

As adding these templates to existing alerts can be difficult while getting familiar with the syntax, I also added a flag, so that errors   that occur during the translation to gotify, will be dispatched with additional information. This is helpful to debug the alert and furthermore that the alert will not be missed by the user.

If you have any questions or advice, feel free to comment or contact me.