### PR TITLE
Added bridge message templating support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The bridge now supports user-defined templating for all inbound messages. The us
 - The default directory for all templates is the root of the bridge in the folder called `templates`.
 - User-defined templating allows matching and linking using the "define" name of the template [Go Templating](https://golang.google.cn/pkg/text/template/).
 - The Gotify software token is used for matching a message template.
-- The Gotify software token with `title=` at the beginning is used for matching a title template.
+- If a template is defined as title=TOKEN, it will be used to render the title of the alert..
 - All file names must be unique but can be any name or subfolder naming you choose.
 - Only one Gotify software token should be defined. More than one will result in inconsistent alerting results.
 - The bridge supports the following template file extensions: "gohtml", "gotmpl", and "tmpl".

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The bridge now supports user-defined templating for all inbound messages. The us
 - The Gotify software token with `title=` at the beginning is used for matching a title template.
 - All file names must be unique but can be any name or subfolder naming you choose.
 - Only one Gotify software token should be defined. More than one will result in inconsistent alerting results.
-- The bridge supports the following template file extensions: "html", "gohtml", "gotmpl", and "tmpl".
+- The bridge supports the following template file extensions: "gohtml", "gotmpl", and "tmpl".
 - Add `-` to prevent extra blank lines. Example: `{{- .Status }}`
 
 #### Usage Hints:

--- a/main.go
+++ b/main.go
@@ -321,6 +321,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 					}
 					defaultTitle = true
 				} else {
+					defaultTitle = false
 					tmplTitle, err := renderTemplate(userTitleTmpl, alert, externalURL)
 					if err != nil {
 						proceed = false
@@ -336,7 +337,6 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 						}
 					} else {
 						title += tmplTitle
-						defaultTitle = false
 					}
 
 					if *svr.debug {
@@ -352,6 +352,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 					}
 					defaultMsg = true
 				} else {
+					defaultMsg = false
 					message, err = renderTemplate(userMsgTmpl, alert, externalURL)
 					if err != nil {
 						proceed = false
@@ -365,8 +366,6 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 							title = "Alertmanager-Gotify-Bridge Error"
 							message = fmt.Sprintf("    Error: %s\n\nAlso check Alertmanager, maybe an alert was raised!\n\nIcomming request:\n%s", err.Error(), b)
 						}
-					} else {
-						defaultMsg = false
 					}
 
 					if *svr.debug {


### PR DESCRIPTION
Yesterday, I added my NetApp storage array through Prometheus for metrics/alerting and realized the sending JSON would not be limited in data because of the fields used, and I would have no easy way of formatting the message since the alerts can not be set up through Grafana.

This got me thinking about how I could implement file templating into the bridge, and once I figured out a plan, I started drafting up the code. 

This PR will allow dedicated user-defined templates based on the Gotify software token. This feature can enable alerts not sent from Grafana to have the ability to present to Gotify cleanly using any `key` value from the JSON.

I had to shuffle around some of the code with a few if/else statements so that you will see a decent chunk of red, but a good amount of the code is just being shifted by `tab`. 

I added several checks to the code and set it up to prevent user-defined templates from crashing the bridge. Anything not done correctly in the templates will have the bridge revert the message to default alerting.

I did not update the docker-compose `ReadMe` section for the bind mount because I did not know how you wanted to add that into the docker, so I left it open for your edits.

Let me know what you think.