### PR TITLE
feature(markdown): Enables markdown notifications support

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,10 +79,10 @@ var (
 	authPassword     = ""
 	metricsNamespace = kingpin.Flag("metrics_namespace", "Metrics Namespace ($METRICS_NAMESPACE)").Envar("METRICS_NAMESPACE").Default("alertmanager_gotify_bridge").String()
 	metricsPath      = kingpin.Flag("metrics_path", "Path under which to expose metrics for the bridge ($METRICS_PATH)").Envar("METRICS_PATH").Default("/metrics").String()
-	extendedDetails  = kingpin.Flag("extended_details", "When enabled, alerts are presented in HTML format and include colorized status (FIR|RES), alert start time, and a link to the generator of the alert ($EXTENDED_DETAILS)").Default("false").Envar("EXTENDED_DETAILS").Bool()
+	extendedDetails  = kingpin.Flag("extended_details", "When enabled, alerts are presented in Markdown format and include status (FIR|RES), alert start time, and a link to the generator of the alert, if set. This flag implies --markdown ($EXTENDED_DETAILS)").Default("false").Envar("EXTENDED_DETAILS").Bool()
 	dispatchErrors   = kingpin.Flag("dispatch_errors", "When enabled, alerts will be tried to dispatch with a error-message regarding faulty templating or missing fields to help debugging ($DISPATCH_ERRORS)").Default("false").Envar("DISPATCH_ERRORS").Bool()
-	markdown         = kingpin.Flag("markdown", "Renders the templates as Markdown ($MARKDOWN)").Default("false").Envar("MARKDOWN").Bool()
-	clickToGenerator = kingpin.Flag("click_to_generator", "Makes the notification clickable, leading to the generator URL ($CLICK_TO_GENERATOR)").Default("false").Envar("CLICK_TO_GENERATOR").Bool()
+	markdown         = kingpin.Flag("markdown", "Renders the templates as Markdown, this flag is implied when using --extended_details ($MARKDOWN)").Default("false").Envar("MARKDOWN").Bool()
+	clickToGenerator = kingpin.Flag("click_to_generator", "Makes the notification clickable, leading to the generator URL, if it is set ($CLICK_TO_GENERATOR)").Default("false").Envar("CLICK_TO_GENERATOR").Bool()
 
 	debug   = kingpin.Flag("debug", "Enable debug output of the server").Bool()
 	metrics = make(map[string]int)
@@ -294,27 +294,22 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			if *extendedDetails {
-				// set text to html
-				extrasContentType := make(map[string]string)
-				extrasContentType["contentType"] = "text/html"
-				extras["client::display"] = extrasContentType
-
-				switch alert.Status {
-				case "resolved":
-					message += "<font style='color: #00b339;' data-mx-color='#00b339'>RESOLVED</font><br/> "
-					title += "[RES] "
-				case "firing":
-					message += "<font style='color: #b31e00;' data-mx-color='#b31e00'>FIRING</font><br/> "
-					title += "[FIR] "
-				}
-			}
-
-			if *markdown {
+			if *markdown || *extendedDetails {
 				// set text to markdown
 				extrasContentType := make(map[string]string)
 				extrasContentType["contentType"] = "text/markdown"
 				extras["client::display"] = extrasContentType
+			}
+
+			if *extendedDetails {
+				switch alert.Status {
+				case "resolved":
+					message += "**RESOLVED**\n"
+					title += "[RES] "
+				case "firing":
+					message += "**FIRING**\n"
+					title += "[FIR] "
+				}
 			}
 
 			// Checks if user defined templates exist
@@ -476,14 +471,14 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 
 			if *extendedDetails {
 				if strings.HasPrefix(alert.GeneratorURL, "http") {
-					message += "<br/><a href='" + alert.GeneratorURL + "'>go to source</a>"
+					message += "\n\n[Go to source](" + alert.GeneratorURL + ")"
 					extrasNotification := make(map[string]map[string]string)
 					extrasNotification["click"] = make(map[string]string)
 					extrasNotification["click"]["url"] = alert.GeneratorURL
 					extras["client::notification"] = extrasNotification
 				}
 				if alert.StartsAt != "" {
-					message += "<br/><br/><i><font style='color: #999999;' data-mx-color='#999999'> alert created at: " + alert.StartsAt[:19] + "</font></i><br/>"
+					message += "\n\n*Alert created at: " + alert.StartsAt[:19] + "*\n\n"
 				}
 			}
 
@@ -492,7 +487,7 @@ func (svr *bridge) handleCall(w http.ResponseWriter, r *http.Request) {
 				// extendedDetails, mainly this is to work with the markdown formatting
 				// so there is no need to add HTML to the notification, and not disturb
 				// the existing flags.
-				if strings.HasPrefix(alert.GeneratorURL, "http") {
+				if alert.GeneratorURL != "" && strings.HasPrefix(alert.GeneratorURL, "http") {
 					extrasNotification := make(map[string]map[string]string)
 					extrasNotification["click"] = make(map[string]string)
 					extrasNotification["click"]["url"] = alert.GeneratorURL


### PR DESCRIPTION
This pull request enables the support for markdown being rendered properly on the client side via a `--markdown` flag (or the corresponding `MARKDOWN` environment variable). This also removes the support for HTML as it is not supported on gotify mobile.

This has the side effect of not allowing to add colours in the notifications, but that didn't work initially anyways.

Similarly it allows to set a `--click_to_generator` flag (`CLICK_TO_GENERATOR` environment variable) that allows to make the client notification clickable when opened on mobile. Previously this behaviour implied the use of `--extended_details`, but this would also force the use of HTML, which is not supported (as per #31 and my own testing).

End result, the following alert would show up as follows

```json
{
  "receiver": "webhook",
  "status": "firing",
  "alerts": [
    {
      "status": "firing",
      "labels": {
        "alertname": "TestAlertName",
        "dc": "eu-west-1",
        "instance": "somehost.fr",
        "job": "prometheus"
      },
      "annotations": {
        "description": "some description **but with** _markdown_ ~~test~~ [a link](https://google.fr)",
        "summary": "This is the alert summary, something is really bad",
        "priority": "critical"
      },
      "startsAt": "2018-08-03T09:52:26.739266876+02:00",
      "endsAt": "0001-01-01T00:00:00Z",
      "generatorURL": "https://google.fr"                                                                                  
    }
  ],
  "externalURL": "http://example.com:9093",
  "version": "4",
  "groupKey": "{}:{alertname=\"Test\", job=\"prometheus\"}"
}
```

On web:
![Screenshot from 2024-02-17 12-29-23](https://github.com/DRuggeri/alertmanager_gotify_bridge/assets/3941401/c681dacb-56e4-4642-aea0-8e3adc24bdfa)


On the app:
![image](https://github.com/DRuggeri/alertmanager_gotify_bridge/assets/3941401/beaeb9f2-1f8c-4666-aeb7-59a543d6f015)

The notification sends me to the generator URL specified in the alert when I click on it on mobile, and nothing happens when the generator URL is absent from the json.

For reproducibility, the templates I used are:
_title.tmpl_:
```gotmpl
{{ define "title=TOKEN" }}
{{- if eq (.Status) ("firing") }}🔥 {{ .Labels.alertname }}{{else}}✅ {{ .Labels.alertname }}{{end}}
{{end}}
```

_main.tmpl_:
```gotmpl
{{- define "TOKEN" -}}
{{- .Annotations.summary }}

{{ .Annotations.description }}

**Labels**:
{{ range $key, $value := .Labels -}}
{{ $key }} = {{ $value }}
{{ end }}
{{- end }}
```