### PR TITLE
Update invalid casing ghcr.io links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ An official scratch-based Docker image is built with every tag and pushed to Doc
 
 The following images are available for use:
 - [druggeri/alertmanager_gotify_bridge](https://hub.docker.com/r/druggeri/alertmanager_gotify_bridge)
-- [ghcr.io/DRuggeri/alertmanager_gotify_bridge](https://ghcr.io/DRuggeri/alertmanager_gotify_bridge)
+- [ghcr.io/druggeri/alertmanager_gotify_bridge](https://ghcr.io/druggeri/alertmanager_gotify_bridge)
 
 ### Docker-Compose
 ```


### PR DESCRIPTION
Discovered this was an issue when I encountered the following.

```
# docker pull ghcr.io/DRuggeri/alertmanager_gotify_bridge
invalid reference format: repository name (DRuggeri/alertmanager_gotify_bridge) must be lowercase
```